### PR TITLE
Let pysaml2 send LogoutResponses

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,0 +1,7 @@
+# ckanext-saml2 change log
+
+## Next release
+
+**Note**: This release requires the use of pysaml2's challenge_decider to enable single logout, which was not required in 0.1. See the sample who.ini configuration.
+
+* Move responsibility for sending LogoutResponses from the plugin to pysaml2

--- a/README.md
+++ b/README.md
@@ -75,3 +75,8 @@ saml2.sp_initiates_slo = true
 - Add `saml2.default_org` and `saml2.default_role` - that values will be assigned to newly created users as organization and role in this organization accordingly
 - In order to enable native login and registration as default option, add `saml2.enable_native_login = true|false` directive to config file.
 - `saml2.login_form_sso_text = BUTTON_TEXT` allows you to controll label of SSO button at login page(default: 'Login with SSO').
+
+
+
+#### Known Issues
+- The only binding supported for sending logout reponses for an IdP-initiated global logout is HTTP Redirect. As of v4.4.0 pysaml2's behaviour is to use a Post binding if the SP receives a logout request via either a Post or Redirect binding but it subsequently raises an exception. A workaround is modify the local copy of the IdP metadata by removing the element that declares support for the Post binding for logout, e.g., `<md:SingleLogoutService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" ... />`, which will cause pysaml2 to revert to a Redirect binding.

--- a/ckanext/saml2/config/who.ini.sample
+++ b/ckanext/saml2/config/who.ini.sample
@@ -1,62 +1,44 @@
 [plugin:auth_tkt]
 use = repoze.who.plugins.auth_tkt:make_plugin
-secret = somesecret
 
-##[plugin:friendlyform]
-##use = repoze.who.plugins.friendlyform:FriendlyFormPlugin
-##login_form_url= /user/login
-##login_handler_path = /login_generic
-##logout_handler_path = /user/logout
-##rememberer_name = auth_tkt
-##post_login_url = /user/logged_in
-##post_logout_url = /user/logged_out
-
-##[plugin:basicauth]
-##use = repoze.who.plugins.basicauth:make_plugin
-##realm = 'CKAN'
+[plugin:friendlyform]
+use = repoze.who.plugins.friendlyform:FriendlyFormPlugin
+login_form_url= /user/login
+login_handler_path = /login_generic
+logout_handler_path = /user/logout
+rememberer_name = auth_tkt
+post_login_url = /user/logged_in
+post_logout_url = /user/logged_out
+charset = utf-8
 
 [plugin:saml2auth]
-use = s2repoze.plugins.sp:make_plugin
+use = saml2.s2repoze.plugins.sp:make_plugin
 saml_conf = ckanext.saml2.config.sp_config
-rememberer_name = auth_tkt
-sid_store = outstanding
-identity_cache = memcached
+remember_name = auth_tkt
+sid_store = /tmp/default/sp_sid_store
+identity_cache = /tmp/default/sp_identity_cache
 
-##[plugin:openid]
-##use = repoze.who.plugins.openid:make_identification_plugin
-##store = file
-##store_file_path = /tmp/sstore
-###openid_field = openid
-##openid_field = openid_identifier
-##came_from_field = came_from
-##error_field = error
-##session_name = beaker.session
-##login_form_url = /user/login
-##login_handler_path = /login_openid
-##logout_handler_path = /user/logout
-### important they go via here after login
-##logged_in_url = /user/logged_in
-##logged_out_url = /user/logged_out
-##rememberer_name = auth_tkt
-# Not supported without an upgrade to "repoze.who.plugins.openid>=0.5.3"
-#ax_optional = nickname=http://axschema.org/namePerson/friendly email=http://schema.openid.net/contact/email fullname=http://axschema.org/namePerson
-#sreg_optional = nickname email fullname
-
+[plugin:saml2_challenge_decider]
+use = saml2.s2repoze.plugins.challenge_decider:make_plugin
+path_login = /user/login
 
 [general]
 request_classifier = repoze.who.classifiers:default_request_classifier
-challenge_decider = repoze.who.classifiers:default_challenge_decider
-#challenge_decider = repoze.who.plugins.openid.classifiers:openid_challenge_decider
+challenge_decider = saml2_challenge_decider
 
 [identifiers]
 plugins =
     saml2auth
     auth_tkt
+    friendlyform;browser
 
 [authenticators]
 plugins =
     saml2auth
+    auth_tkt
+    ckan.lib.authenticator:UsernamePasswordAuthenticator
 
 [challengers]
 plugins =
     saml2auth
+    friendlyform;browser

--- a/ckanext/saml2/plugin.py
+++ b/ckanext/saml2/plugin.py
@@ -564,20 +564,14 @@ class Saml2Controller(UserController):
         """SAML magic."""
         environ = p.toolkit.request.environ
         # so here I might get either a LogoutResponse or a LogoutRequest
-        client = environ['repoze.who.plugins']['saml2auth']
         if 'QUERY_STRING' in environ:
             saml_resp = p.toolkit.request.GET.get('SAMLResponse', '')
             saml_req = p.toolkit.request.GET.get('SAMLRequest', '')
 
             if saml_req:
                 log.debug('Received SLO request from IdP')
-                # Ignore whatever the pysaml2 plugin did, which as of
-                # 4.0.0 seems broken, and do it ourselves
-                name_id = unserialise_nameid(environ.get('REMOTE_USER'))
-                response = client.saml_client.handle_logout_request(
-                    saml_req, name_id, BINDING_HTTP_REDIRECT)
-                location = client._handle_logout(response).location()
-                h.redirect_to(location, code=303)
+                # pysaml2 takes care of everything here via its
+                # repoze.who plugin
             elif saml_resp:
              #   # fix the cert so that it is on multiple lines
              #   out = []


### PR DESCRIPTION
Basically, let pysaml2 do what it's supposed to.

_Note that this is a breaking change_ and requires that repoze.who is configured to use pysaml2's challenge decider. Only supports responses via Redirect binding.

This also depends on fixes not yet merged into pysaml2: https://github.com/rohe/pysaml2/pull/393, https://github.com/rohe/pysaml2/pull/394, and https://github.com/rohe/pysaml2/pull/395. These are merged into https://github.com/DataShades/pysaml2/tree/uat and hopefully will be in the upstream v4.5.0.