### PR TITLE
Consolidate the id stored against the Saml2 user to avoid duplicates

### DIFF
--- a/ckanext/saml2/plugin.py
+++ b/ckanext/saml2/plugin.py
@@ -321,7 +321,7 @@ class Saml2Plugin(p.SingletonPlugin):
         try:
             # Update the user account from the authentication response
             # every time
-            c.userobj = self._create_or_update_user(c.user, saml_info)
+            c.userobj = self._create_or_update_user(c.user, saml_info, name_id)
             c.user = c.userobj.name
         except Exception as e:
             log.error(
@@ -389,7 +389,7 @@ class Saml2Plugin(p.SingletonPlugin):
             redirect_after_login = config.get('saml2.redirect_after_login', '/dashboard')
             h.redirect_to(redirect_after_login)
 
-    def _create_or_update_user(self, user_name, saml_info):
+    def _create_or_update_user(self, user_name, saml_info, name_id):
         """Create or update the subject's user account and return the user
         object"""
         data_dict = {}
@@ -426,7 +426,6 @@ class Saml2Plugin(p.SingletonPlugin):
         if is_new_user:
             email = _take_from_saml_or_user('email', saml_info, data_dict)
             new_user_username = _get_random_username_from_email(email)
-            name_id = _take_from_saml_or_user('id', saml_info, data_dict)
             data_dict['name'] = new_user_username
             data_dict['id'] = unicode(uuid.uuid4())
             log.debug("Creating user: %s", data_dict)


### PR DESCRIPTION
At the beggining of the indentify process, a NameId is extracted from the payload that the Saml2 backend sends, and that is set on `environ['REMOTE_USER']` by repoze.who:

https://github.com/DataShades/ckanext-saml2/blob/91ccffd3ec96d76d9f3b4fdc59d6140a0c04ef8e/ckanext/saml2/plugin.py#L295:L298

In my case this payload was:

```
REMOTE_USER = "2=urn%3Aoasis%3Anames%3Atc%3ASAML%3A1.1%3Anameid-format%3AemailAddress,4=amercader%40rockfound.org"
```

So the NameId extracted was `amercader@rockfound.org`.

This NameId is immediately used to check if a Saml2 user with the same name id exists in the database.

The problem is that when creating a new instance of a Saml2User, the extension is using a different id:

https://github.com/DataShades/ckanext-saml2/blob/91ccffd3ec96d76d9f3b4fdc59d6140a0c04ef8e/ckanext/saml2/plugin.py#L429

This `saml_info` comes from `environ["repoze.who.identity"]["user"]` and in my case `environ["repoze.who.identity"]["user"]["id"]` (what is used when creating the new `SAML2User`) was just `amercader`.

This meant that every time I tried to log in, the extension couldn't find any existing user with NameId `amercader@rockfound.org`, so it tried to create a new one (and failed because of the SAML2User.name_id unique constraint).

This patch ensures that the same key that is used to check if a user exists is the one that is actually stored.

I assume that in most scenarios these two ids are the same and that's why this hasn't been an issue so far.